### PR TITLE
Rename DATABASE_URI -> DATABASE_URL var

### DIFF
--- a/webserver/src/config.js
+++ b/webserver/src/config.js
@@ -45,7 +45,7 @@ export default function getConfig(): Config {
   const numberSystemArray = validateNumberSystem(numberSystemStr);
 
   return {
-    pgUrl: requireEnv('DATABASE_URI'),
+    pgUrl: requireEnv('DATABASE_URL'),
     numberSystemArray,
     debug,
   };


### PR DESCRIPTION
Needed because Heroku will not allow me to change the environment variable name for that particular variable